### PR TITLE
Updated default truffle configuration to put compiled files back in default location

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -5,7 +5,6 @@ const path = require('path');
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
-  contracts_build_directory: path.join(__dirname, "client/src/contracts"),
   networks: {
     development: {
       host: "127.0.0.1",     // Localhost (default: none)


### PR DESCRIPTION
Removed the configuration element to put the contract output back in the default location.