### PR TITLE
Updated truffle hd wallet provider version and removed the sub path for contract output

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "truffle-hdwallet-provider": "^1.0.7"
+    "truffle-hdwallet-provider": "1.0.6"
   }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -5,7 +5,6 @@ const path = require('path');
 module.exports = {
   // See <http://truffleframework.com/docs/advanced/configuration>
   // to customize your Truffle configuration!
-  contracts_build_directory: path.join(__dirname, "client/src/contracts"),
   networks: {
     development: {
       host: "127.0.0.1",     // Localhost (default: none)


### PR DESCRIPTION
Set the trufflehd-wallet-provider to version 1.0.6 (1.0.7 seems to be having some issues) and removed the contracts_build_directory to allow contract output to the default location. 