### PR TITLE
Updating base template to support version 1.0.17 of truffle-hdwallet-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "truffle-hdwallet-provider": "1.0.10"
+    "truffle-hdwallet-provider": "^1.0.17"
   }
 }


### PR DESCRIPTION
The current base template used v1.0.10 for some legacy issues, however these have been resolved and use of the latest stable (1.0.17) is working now.