### PR TITLE
Update to configuration to remove restriction for solc version

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,24 +1,14 @@
-const HDWalletProvider = require('truffle-hdwallet-provider');
-const fs = require('fs');
+const HDWalletProvider = require("truffle-hdwallet-provider");
+const fs = require("fs");
 
 module.exports = {
-  // See <http://truffleframework.com/docs/advanced/configuration>
-  // to customize your Truffle configuration!
-  networks: {
-    development: {
-      host: "127.0.0.1",     // Localhost (default: none)
-      port: 8545,            // Standard Ethereum port (default: none)
-      network_id: "*",       // Any network (default: none)
+    // See <http://truffleframework.com/docs/advanced/configuration>
+    // to customize your Truffle configuration!
+    networks: {
+        development: {
+            host: "127.0.0.1", // Localhost (default: none)
+            port: 8545, // Standard Ethereum port (default: none)
+            network_id: "*" // Any network (default: none)
+        }
     }
-  },
-  // Set default mocha options here, use special reporters etc.
-  mocha: {
-    // timeout: 100000
-  },
-  // Configure your compilers
-  compilers: {
-    solc: {
-      version: "0.5.0"
-    }
-  }
 };


### PR DESCRIPTION
Removing the solc compiler version that was implicit in the configuration by default.  There is no need for this now.